### PR TITLE
Bind the onload event

### DIFF
--- a/svg4everybody.ie8.js
+++ b/svg4everybody.ie8.js
@@ -61,7 +61,7 @@
 
 						xhr.open('GET', url_root);
 
-						xhr.onload = onload;
+						xhr.onload = onload.bind(xhr);
 
 						xhr.send();
 					}

--- a/svg4everybody.js
+++ b/svg4everybody.js
@@ -53,7 +53,7 @@
 
 					xhr.open('GET', url_root);
 
-					xhr.onload = onload;
+					xhr.onload = onload.bind(xhr);
 
 					xhr.send();
 				}


### PR DESCRIPTION
Prevents "Unable to get property 'splice' of undefined or null reference" error in IE11
